### PR TITLE
Fix spelling errors in variable names and function calls

### DIFF
--- a/pages/apis/index.mdx
+++ b/pages/apis/index.mdx
@@ -2,7 +2,7 @@
 
 **[Mintscan API](https://api.mintscan.io)**, integral to Mintscan 2.0, stems from enterprise-grade onchain data indexing. Through features like tx builder and historical statistics APIs, it offers easy access to dynamic onchain data, including account balances and staking APR. Streamlining raw data processing, Mintscan API simplifies Interchain dapp development, positioning itself as a key piece in the Interchain infrastructure puzzle.
 
-For inquery, please contact us api@cosmostation.io
+For inquiry, please contact us api@cosmostation.io
 
 ## How to get API Key?
 

--- a/pages/mintstation/module.mdx
+++ b/pages/mintstation/module.mdx
@@ -123,7 +123,7 @@ import  "gogoproto/gogo.proto";
 import  "google/protobuf/timestamp.proto";
 import  "cosmos_proto/cosmos.proto";
 option  go_package = "github.com/cosmostation/mintstation/x/greet/types";
-// our gensis state message will be empty for this tutorial
+// our genesis state message will be empty for this tutorial
 message  GenesisState {}
 ```
 
@@ -164,7 +164,7 @@ const (
 	QueryGetGreeting =  "get-greeting"  // used for legacy querier routing
 	QueryListGreetings =  "list-greetings"// used for legacy querier routing
 )
-// heler function simply returns []byte out of a prefix string
+// helper function simply returns []byte out of a prefix string
 func  KeyPrefix(p string) []byte {
 	return []byte(p)
 }
@@ -186,7 +186,7 @@ Our `MsgCreateGreet` struct was created when we generated our Proto Types, we no
 
 ```
 // MsgCreateGreet we defined it here to get type checking
-//to make sure we are immplementing it correctly
+//to make sure we are implementing it correctly
 var _ sdk.Msg =  &MsgCreateGreet{}
 
 
@@ -225,7 +225,7 @@ func (m *MsgCreateGreet) GetSigners() []sdk.AccAddress {
 now that we have our `MsgCreateGreet` implement the `sdk.Msg` interface let's register our codec for marshaling/unmarshaling our greeting we will register both the deprecated legacy amino and the new Interface registry.
 
 ```
-// registers the marshal/unmarsahl for greating a new greeting for our legacy amino codec
+// registers the marshal/unmarshal for creating a new greeting for our legacy amino codec
 func  RegisterLegacyAminoCodec(cdc *codec.LegacyAmino){
 	cdc.RegisterConcrete(&MsgCreateGreet{}, "greet/CreateGreet", nil)
 }
@@ -403,7 +403,7 @@ func  NewQuerier(k Keeper, legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
 			}
 			return bz, nil
 		default:
-			return  nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknow request at %s query endpoint", types.ModuleName)
+			return  nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown request at %s query endpoint", types.ModuleName)
 		}
 	}
 }


### PR DESCRIPTION
1. inquery → inquiry:  The correct spelling is inquiry.
2. gensis → genesis: Corrected the typo in the variable name gensis to genesis.
3. heler → helper: Fixed the misspelling in the variable name heler to helper.
4. immplementing → implementing: Corrected the spelling of immplementing to the proper implementing.
5. unmarsahl → unmarshal: Fixed the typo unmarsahl to unmarshal, which is the correct function name used for converting data from a specific format.
6. greating → creating: Corrected the misspelled variable greating to creating.